### PR TITLE
Add Gamepad controller

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -12,6 +12,7 @@ import ActionRadialExplosionButton from '@/entities/GameActions/ui/ActionButtons
 import ActionGravitationButton from '@/entities/GameActions/ui/ActionButtons/ActionGravitationButton.vue';
 import ActionForwardImpulseButton from '@/entities/GameActions/ui/ActionButtons/ActionForwardImpulseButton.vue';
 import KeyBoardController from '@/entities/Game/controllers/KeyBoardController';
+import GamepadController from '@/entities/Game/controllers/GamepadController';
 import AdapterControllerWithGame from '@/entities/Game/AdapterControllerWithGame';
 import GameContainer from '@/shared/UiKit/GameContainer/GameContainer.vue';
 import router from '@/app/router';
@@ -19,6 +20,7 @@ import router from '@/app/router';
 const gameCanvas = ref<HTMLCanvasElement>();
 let game: Game;
 let adapterController: ReturnType<typeof AdapterControllerWithGame>;
+let adapterGamepad: ReturnType<typeof AdapterControllerWithGame>;
 
 // controller
 const buttonAction1Timestamp = ref<number>(0);
@@ -58,12 +60,14 @@ onMounted(() => {
     });
 
     adapterController = AdapterControllerWithGame(KeyBoardController, game);
+    adapterGamepad = AdapterControllerWithGame(GamepadController, game);
   });
 });
 
 onBeforeUnmount(() => {
   game.dispose();
   adapterController.destroy();
+  adapterGamepad.destroy();
 });
 
 window.addEventListener('resize', function () {

--- a/src/entities/Game/AdapterControllerWithGame.ts
+++ b/src/entities/Game/AdapterControllerWithGame.ts
@@ -12,7 +12,11 @@ export default function AdapterControllerWithGame(
   });
 
   const movementEvents = controller.movementEvents$.subscribe((payload) => {
-    game.setPlayerDirection(payload.direction, payload.isPressed);
+    game.setPlayerDirection(
+      payload.direction,
+      payload.isPressed,
+      payload.speed ?? 1
+    );
   });
 
   return {

--- a/src/entities/Game/Game.ts
+++ b/src/entities/Game/Game.ts
@@ -123,8 +123,8 @@ export default class Game {
   private _havokInstance: HavokPhysicsWithBindings;
   private _checkPointPosition: Vector3 = new Vector3(0, 30, 0);
   private _shadow: ShadowGenerator;
-  private _movementDirection: Set<MOVEMENT_DIRECTION> = new Set([]);
-  private _cameraDirection: Set<CAMERA_DIRECTION> = new Set([]);
+  private _movementDirection: Map<MOVEMENT_DIRECTION, number> = new Map();
+  private _cameraDirection: Map<CAMERA_DIRECTION, number> = new Map();
   private _physicsHelper: PhysicsHelper | null = null;
   private readonly _levelEnvironment: LevelEnvironment;
 
@@ -442,11 +442,13 @@ export default class Game {
     // angle in degrees per second
     const rotationSpeed = 2;
 
-    if (this._cameraDirection.has('CAMERA_LEFT')) {
-      this._cameraAngle += rotationSpeed * deltaTime;
+    const leftSpeed = this._cameraDirection.get('CAMERA_LEFT');
+    if (leftSpeed) {
+      this._cameraAngle += rotationSpeed * deltaTime * leftSpeed;
     }
-    if (this._cameraDirection.has('CAMERA_RIGHT')) {
-      this._cameraAngle -= rotationSpeed * deltaTime;
+    const rightSpeed = this._cameraDirection.get('CAMERA_RIGHT');
+    if (rightSpeed) {
+      this._cameraAngle -= rotationSpeed * deltaTime * rightSpeed;
     }
   }
 
@@ -488,7 +490,11 @@ export default class Game {
     }
   }
 
-  public setPlayerDirection(direction: DIRECTION, isPressed: boolean) {
+  public setPlayerDirection(
+    direction: DIRECTION,
+    isPressed: boolean,
+    speed: number = 1
+  ) {
     if (direction === 'JUMP' && isPressed) {
       Object.values(this._playerCancelableActions).forEach((action) => {
         action.callEndActionStatus();
@@ -497,14 +503,14 @@ export default class Game {
     // todo refactor
     if (direction === 'CAMERA_LEFT' || direction === 'CAMERA_RIGHT') {
       if (isPressed) {
-        this._cameraDirection.add(direction);
+        this._cameraDirection.set(direction, speed);
       } else {
         this._cameraDirection.delete(direction);
       }
       return;
     }
     if (isPressed) {
-      this._movementDirection.add(direction);
+      this._movementDirection.set(direction, speed);
     } else {
       this._movementDirection.delete(direction);
     }

--- a/src/entities/Game/controllers/AbstractController.ts
+++ b/src/entities/Game/controllers/AbstractController.ts
@@ -5,6 +5,7 @@ export type PlayerActionPayload = PLAYER_ACTION;
 export type MovementPayload = {
   direction: DIRECTION;
   isPressed: boolean;
+  speed?: number;
 };
 
 export default abstract class AbstractController {

--- a/src/entities/Game/controllers/GamepadController.ts
+++ b/src/entities/Game/controllers/GamepadController.ts
@@ -1,0 +1,238 @@
+import { fromEvent, Subject } from 'rxjs';
+import AbstractController, {
+  type PlayerActionPayload,
+  type MovementPayload,
+} from '@/entities/Game/controllers/AbstractController';
+import type { DIRECTION, PLAYER_ACTION } from '@/entities/Game/Game';
+import {
+  decodeHat,
+  HAT_EPSILON,
+  type HatDirection,
+} from './GamepadController.utils';
+
+export const GAMEPAD_AXES = {
+  LEFT_STICK_X: 0,
+  LEFT_STICK_Y: 1,
+  RIGHT_STICK_X: 2,
+  RIGHT_STICK_Y: 3,
+} as const;
+
+export const GAMEPAD_BUTTONS = {
+  X: 0,
+  O: 1,
+  SQUARE: 2,
+  TRIANGLE: 3,
+  L1: 4,
+  R1: 5,
+  L2: 6,
+  R2: 7,
+  SHARE: 8,
+  OPTIONS: 9,
+  L3: 10,
+  R3: 11,
+  DPAD_UP: 12,
+  DPAD_DOWN: 13,
+  DPAD_LEFT: 14,
+  DPAD_RIGHT: 15,
+  PS: 16,
+  TOUCH: 17,
+} as const;
+
+export type BindDirectionControls = {
+  axisX: number;
+  axisY: number;
+  axisCamera: number;
+};
+
+export type BindDirectionKeys = Partial<
+  Record<keyof typeof GAMEPAD_BUTTONS, DIRECTION>
+>;
+export type BindActionButtons = Partial<
+  Record<keyof typeof GAMEPAD_BUTTONS, PLAYER_ACTION>
+>;
+
+export const DEFAULT_DIRECTION_CONTROLS: BindDirectionControls = {
+  axisX: GAMEPAD_AXES.LEFT_STICK_X,
+  axisY: GAMEPAD_AXES.LEFT_STICK_Y,
+  axisCamera: GAMEPAD_AXES.RIGHT_STICK_X,
+};
+
+export const DEFAULT_DIRECTION_KEYS: BindDirectionKeys = {
+  DPAD_UP: 'FORWARD',
+  DPAD_DOWN: 'BACKWARD',
+  DPAD_LEFT: 'LEFT',
+  DPAD_RIGHT: 'RIGHT',
+  X: 'JUMP',
+} as const;
+
+export const DEFAULT_ACTION_BUTTONS: BindActionButtons = {
+  SQUARE: 'ACTION1',
+  O: 'ACTION2',
+  TRIANGLE: 'ACTION3',
+  R1: 'ACTION4',
+  R2: 'ACTION5',
+};
+
+const DEFAULT_THRESHOLD = 0.3;
+const POLL_INTERVAL = 16;
+
+interface DirectionState {
+  pressed: boolean;
+  speed: number;
+}
+
+export default class GamepadController extends AbstractController {
+  private _bindDirectionControls = DEFAULT_DIRECTION_CONTROLS;
+  private _bindDirectionKeys = DEFAULT_DIRECTION_KEYS;
+  private _bindActionButtons = DEFAULT_ACTION_BUTTONS;
+  private _threshold = DEFAULT_THRESHOLD;
+
+  private _gamepadIndex: number | null = null;
+  private _intervalId = 0;
+  private _buttonState = new Map<string, boolean>();
+  private _directionState = new Map<
+    MovementPayload['direction'],
+    DirectionState
+  >();
+  private readonly _actionSubject = new Subject<PlayerActionPayload>();
+  private readonly _movementSubject = new Subject<MovementPayload>();
+
+  public readonly actionEvents$ = this._actionSubject.asObservable();
+  public readonly movementEvents$ = this._movementSubject.asObservable();
+
+  constructor(payload?: {
+    bindDirectionControls?: BindDirectionControls;
+    bindDirectionKeys?: BindDirectionKeys;
+    bindActionButtons?: BindActionButtons;
+    threshold?: number;
+  }) {
+    super();
+    if (payload?.bindDirectionControls) {
+      this._bindDirectionControls = payload.bindDirectionControls;
+    }
+    if (payload?.bindDirectionKeys) {
+      this._bindDirectionKeys = payload.bindDirectionKeys;
+    }
+    if (payload?.bindActionButtons) {
+      this._bindActionButtons = payload.bindActionButtons;
+    }
+    if (payload?.threshold !== undefined) {
+      this._threshold = payload.threshold;
+    }
+
+    fromEvent<GamepadEvent>(window, 'gamepadconnected').subscribe((event) => {
+      if (this._gamepadIndex === null) {
+        this._gamepadIndex = event.gamepad.index;
+        this._startLoop();
+      }
+    });
+
+    fromEvent<GamepadEvent>(window, 'gamepaddisconnected').subscribe(
+      (event) => {
+        if (this._gamepadIndex === event.gamepad.index) {
+          this._gamepadIndex = null;
+          clearInterval(this._intervalId);
+        }
+      }
+    );
+  }
+
+  destroy(): void {
+    clearInterval(this._intervalId);
+    this._actionSubject.complete();
+    this._movementSubject.complete();
+  }
+
+  private _startLoop() {
+    this._intervalId = window.setInterval(() => this._poll(), POLL_INTERVAL);
+  }
+
+  private _updateDirection(
+    direction: MovementPayload['direction'],
+    pressed: boolean,
+    speed: number
+  ) {
+    const prev = this._directionState.get(direction);
+    if (
+      !prev ||
+      prev.pressed !== pressed ||
+      Math.abs(prev.speed - speed) > 0.05
+    ) {
+      this._movementSubject.next({ direction, isPressed: pressed, speed });
+      this._directionState.set(direction, { pressed, speed });
+    }
+  }
+
+  private _normalizeAxis(val: number): number {
+    return Math.min(
+      1,
+      (Math.abs(val) - this._threshold) / (1 - this._threshold)
+    );
+  }
+
+  private _poll() {
+    if (this._gamepadIndex === null) {
+      return;
+    }
+    const gamepad = navigator.getGamepads()[this._gamepadIndex];
+    if (!gamepad) {
+      return;
+    }
+
+    const { axisX, axisY, axisCamera } = this._bindDirectionControls;
+    const lx = gamepad.axes[axisX] ?? 0;
+    const ly = gamepad.axes[axisY] ?? 0;
+    const rx = gamepad.axes[axisCamera] ?? 0;
+
+    const speeds: Record<DIRECTION, number> = {
+      FORWARD: ly < -this._threshold ? this._normalizeAxis(ly) : 0,
+      BACKWARD: ly > this._threshold ? this._normalizeAxis(ly) : 0,
+      LEFT: lx < -this._threshold ? this._normalizeAxis(lx) : 0,
+      RIGHT: lx > this._threshold ? this._normalizeAxis(lx) : 0,
+      JUMP: 0,
+      CAMERA_LEFT: rx < -this._threshold ? this._normalizeAxis(rx) : 0,
+      CAMERA_RIGHT: rx > this._threshold ? this._normalizeAxis(rx) : 0,
+    };
+
+    const buttonPressed = (name: keyof typeof GAMEPAD_BUTTONS) => {
+      const index = GAMEPAD_BUTTONS[name];
+      return !!gamepad.buttons[index]?.pressed;
+    };
+
+    Object.entries(this._bindDirectionKeys).forEach(([key, direction]) => {
+      if (buttonPressed(key as keyof typeof GAMEPAD_BUTTONS)) {
+        speeds[direction] = Math.max(speeds[direction] || 0, 1);
+      }
+    });
+
+    if (
+      speeds.FORWARD === 0 &&
+      speeds.BACKWARD === 0 &&
+      speeds.LEFT === 0 &&
+      speeds.RIGHT === 0
+    ) {
+      const hat = gamepad.axes[9] ?? gamepad.axes[10];
+      if (hat !== undefined) {
+        const d: HatDirection = decodeHat(hat, HAT_EPSILON);
+        if (d.up) speeds.FORWARD = 1;
+        if (d.down) speeds.BACKWARD = 1;
+        if (d.left) speeds.LEFT = 1;
+        if (d.right) speeds.RIGHT = 1;
+      }
+    }
+
+    Object.entries(this._bindActionButtons).forEach(([key, action]) => {
+      const pressed = buttonPressed(key as keyof typeof GAMEPAD_BUTTONS);
+      const prev = this._buttonState.get(key);
+      if (pressed && !prev) {
+        this._actionSubject.next(action);
+      }
+      this._buttonState.set(key, pressed);
+    });
+
+    (Object.keys(speeds) as Array<DIRECTION>).forEach((dir) => {
+      const speed = speeds[dir];
+      this._updateDirection(dir, speed > 0, speed);
+    });
+  }
+}

--- a/src/entities/Game/controllers/GamepadController.utils.ts
+++ b/src/entities/Game/controllers/GamepadController.utils.ts
@@ -1,0 +1,26 @@
+export interface HatDirection {
+  up?: boolean;
+  down?: boolean;
+  left?: boolean;
+  right?: boolean;
+}
+
+export const HAT_EPSILON = 0.07;
+
+const HAT_POSITIONS: Array<{ val: number } & HatDirection> = [
+  { val: -1, up: true },
+  { val: -0.714, up: true, right: true },
+  { val: -0.428, right: true },
+  { val: -0.142, down: true, right: true },
+  { val: 0.142, down: true },
+  { val: 0.428, down: true, left: true },
+  { val: 0.714, left: true },
+  { val: 1, up: true, left: true },
+];
+
+export function decodeHat(
+  value: number,
+  epsilon: number = HAT_EPSILON
+): HatDirection {
+  return HAT_POSITIONS.find((p) => Math.abs(p.val - value) < epsilon) || {};
+}

--- a/src/entities/Game/controllers/KeyBoardController.ts
+++ b/src/entities/Game/controllers/KeyBoardController.ts
@@ -9,9 +9,7 @@ import {
   distinctUntilChanged,
   scan,
 } from 'rxjs';
-import AbstractController, {
-  type PlayerActionPayload,
-} from '@/entities/Game/controllers/AbstractController';
+import AbstractController from '@/entities/Game/controllers/AbstractController';
 
 type BindActionsKeys = Record<string, PLAYER_ACTION>;
 type BindDoubleActionsKeys = Record<string, PLAYER_ACTION>;
@@ -113,10 +111,13 @@ export default class KeyBoardController extends AbstractController {
     map((keyCode) => ({
       direction: this._bindDirectionKeys[keyCode],
       isPressed: !!this._pressedKeys.get(keyCode),
+      speed: 1,
     })),
     distinctUntilChanged(
       (prev, curr) =>
-        prev.direction === curr.direction && prev.isPressed === curr.isPressed
+        prev.direction === curr.direction &&
+        prev.isPressed === curr.isPressed &&
+        prev.speed === curr.speed
     )
   );
 

--- a/src/entities/Game/services/Player.ts
+++ b/src/entities/Game/services/Player.ts
@@ -179,7 +179,10 @@ export default class Player {
     this.#collisionList.delete(collidedObjectId);
   }
 
-  public move(cameraViewAngle: number, directions: Set<MOVEMENT_DIRECTION>) {
+  public move(
+    cameraViewAngle: number,
+    directions: Map<MOVEMENT_DIRECTION, number>
+  ) {
     if (directions.size === 0) {
       return;
     }
@@ -193,27 +196,37 @@ export default class Player {
 
     let x = 0;
     let z = 0;
-    if (directions.has('FORWARD')) {
-      x += Math.sin(cameraViewAngle);
-      z += Math.cos(cameraViewAngle);
+    const forward = directions.get('FORWARD') ?? 0;
+    const backward = directions.get('BACKWARD') ?? 0;
+    const left = directions.get('LEFT') ?? 0;
+    const right = directions.get('RIGHT') ?? 0;
+
+    if (forward) {
+      x += Math.sin(cameraViewAngle) * forward;
+      z += Math.cos(cameraViewAngle) * forward;
     }
-    if (directions.has('BACKWARD')) {
-      x -= Math.sin(cameraViewAngle);
-      z -= Math.cos(cameraViewAngle);
+    if (backward) {
+      x -= Math.sin(cameraViewAngle) * backward;
+      z -= Math.cos(cameraViewAngle) * backward;
     }
-    if (directions.has('LEFT')) {
-      x -= Math.cos(cameraViewAngle);
-      z += Math.sin(cameraViewAngle);
+    if (left) {
+      x -= Math.cos(cameraViewAngle) * left;
+      z += Math.sin(cameraViewAngle) * left;
     }
-    if (directions.has('RIGHT')) {
-      x += Math.cos(cameraViewAngle);
-      z -= Math.sin(cameraViewAngle);
+    if (right) {
+      x += Math.cos(cameraViewAngle) * right;
+      z -= Math.sin(cameraViewAngle) * right;
     }
     const directionVector = new Vector3(x, 0, z);
 
+    const speed = Math.min(1, directionVector.length());
+    if (speed === 0) {
+      this.playerPhysics.body.setAngularVelocity(Vector3.Zero());
+      return;
+    }
     directionVector.normalize();
     this.playerPhysics.body.setAngularVelocity(
-      directionVector.scale(this.#moveSpeed)
+      directionVector.scale(this.#moveSpeed * speed)
     );
   }
 


### PR DESCRIPTION
## Summary
- integrate `GamepadController` for joystick input
- adapt game API to support analog speed
- wire up keyboard and gamepad controllers in `App.vue`
- update gamepad button names and defaults
- refactor GamepadController with utility functions and partial bindings

## Testing
- `npm run format`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68630884a204832fb16c24df7de9965c